### PR TITLE
Fix data type referred to for django plugin

### DIFF
--- a/doc-source/xray-sdk-python-configuration.md
+++ b/doc-source/xray-sdk-python-configuration.md
@@ -143,7 +143,7 @@ INSTALLED_APPS = [
 ]
 ```
 
-Configure the available settings in a list named `XRAY_RECORDER`\.
+Configure the available settings in a dict named `XRAY_RECORDER`\.
 
 **Example settings\.py – installed apps**  
 


### PR DESCRIPTION
It's a dict not a list.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
