### PR TITLE
Remove leading comma fixing invalid syntax

### DIFF
--- a/doc-source/xray-sdk-python-middleware.md
+++ b/doc-source/xray-sdk-python-middleware.md
@@ -54,7 +54,7 @@ Configure a segment name in your [`settings.py` file](xray-sdk-python-configurat
 **Example settings\.py – segment name**  
 
 ```
-XRAY_RECORDER = {,
+XRAY_RECORDER = {
     'AWS_XRAY_TRACING_NAME': 'My application',
     'PLUGINS': ('EC2Plugin'),
 }


### PR DESCRIPTION
*Issue #, if available:*
n/a

*Description of changes:*
Fix invalid syntax in Django settings.py example by removing a leading comma.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
