### PR TITLE
Add example for a custom http request

### DIFF
--- a/doc-source/xray-sdk-go-httpclients.md
+++ b/doc-source/xray-sdk-go-httpclients.md
@@ -9,3 +9,11 @@ Client creates a shallow copy of the provided http client, defaulting to `http.D
 ```
 myClient := xray.Client(http-client)
 ```
+
+**Custom HTTP client**
+
+```
+request, err := httpNewRequest("PUT", myURL, bytes.NewBuffer(myPayload))
+myClient := xray.Client(&http.Client{})
+response, err := client.Do(request.WithContext(ctx))
+```


### PR DESCRIPTION
Just wrapping the client with the xray client is only half of the solution. You still need to make the request with the context; otherwise, you will get a "Suppressing AWS X-Ray context missing panic: failed to begin subsegment named 'SEGMENT_NAME' segment cannot be found." error

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
