### PR TITLE
Add pymysql to supported libraries list

### DIFF
--- a/doc-source/xray-sdk-python-patching.md
+++ b/doc-source/xray-sdk-python-patching.md
@@ -10,6 +10,7 @@ To instrument downstream calls, use the X\-Ray SDK for Python to patch the libra
 + `[httplib](https://docs.python.org/2/library/httplib.html)`, [https://docs.python.org/3/library/http.client.html](https://docs.python.org/3/library/http.client.html) – Instrument low\-level HTTP clients and the higher level libraries that use them\.
 + `[sqlite3](https://docs.python.org/3/library/sqlite3.html)` – Instrument SQLite clients\.
 + `[mysql\-connector\-python](https://pypi.python.org/pypi/mysql-connector-python)` – Instrument MySQL clients\.
++ `[pymysql](https://pypi.org/project/PyMySQL/)` - Instrument PyMySQL based clients for MySQL & MariaDB\.
 
 When you use a patched library, the X\-Ray SDK for Python creates a subsegment for the call and records information from the request and response\. A segment must be available for the SDK to create the subsegment, either from the SDK middleware or from AWS Lambda\.
 


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:*
Add `pymysql` to the list of supported libraries for Python SDK.

I have submitted a PR [#215](https://github.com/aws/aws-xray-sdk-python/pull/215) for adding `pymysql` support to the SDK.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
