### PR TITLE
X-Ray Python SDK - Include psycopg2 as a supported library

### DIFF
--- a/doc-source/xray-sdk-python-patching.md
+++ b/doc-source/xray-sdk-python-patching.md
@@ -11,6 +11,7 @@ To instrument downstream calls, use the X\-Ray SDK for Python to patch the libra
 + `[sqlite3](https://docs.python.org/3/library/sqlite3.html)` – Instrument SQLite clients\.
 + `[mysql\-connector\-python](https://pypi.python.org/pypi/mysql-connector-python)` – Instrument MySQL clients\.
 + `[pymysql](https://pypi.org/project/PyMySQL/)` - Instrument PyMySQL based clients for MySQL & MariaDB\.
++ `[psycopg2](https://pypi.org/project/psycopg2/)` - Instrument Psycopg2 based clients for PostgreSQL\.
 
 When you use a patched library, the X\-Ray SDK for Python creates a subsegment for the call and records information from the request and response\. A segment must be available for the SDK to create the subsegment, either from the SDK middleware or from AWS Lambda\.
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

`psycopg2` is already supported by X-Ray core patcher since 2.1. This PR updates the doc to reflect X-Ray Python SDK GitHub

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
