### PR TITLE
Implement more consistent capitalisation in Java Spring AOP

### DIFF
--- a/doc-source/index.md
+++ b/doc-source/index.md
@@ -92,7 +92,7 @@ Amazon's trademarks and trade dress may not be used in
    + [Add annotations and metadata to segments with the X-Ray SDK for Java](xray-sdk-java-segment.md)
    + [AWS X-Ray metrics for the X-Ray SDK for Java](xray-sdk-java-monitoring.md)
    + [Passing segment context between threads in a multithreaded application](xray-sdk-java-multithreading.md)
-   + [AOP with spring and the X-Ray SDK for Java](xray-sdk-java-aop-spring.md)
+   + [AOP with Spring and the X-Ray SDK for Java](xray-sdk-java-aop-spring.md)
 + [AWS X-Ray SDK for Node.js](xray-sdk-nodejs.md)
    + [Configuring the X-Ray SDK for Node.js](xray-sdk-nodejs-configuration.md)
    + [Tracing incoming requests with the X-Ray SDK for Node.js](xray-sdk-nodejs-middleware.md)

--- a/doc-source/xray-sdk-java-aop-spring.md
+++ b/doc-source/xray-sdk-java-aop-spring.md
@@ -1,10 +1,10 @@
-# AOP with spring and the X\-Ray SDK for Java<a name="xray-sdk-java-aop-spring"></a>
+# AOP with Spring and the X\-Ray SDK for Java<a name="xray-sdk-java-aop-spring"></a>
 
 This topic describes how to use the X\-Ray SDK and the Spring Framework to instrument your application without changing its core logic\. This means that there is now a non\-invasive way to instrument your applications running remotely in AWS\.
 
 You must perform three tasks to enable this feature\.
 
-**To enable AOP in spring**
+**To enable AOP in Spring**
 
 1. [Configure Spring](#xray-sdk-java-aop-spring-configuration)
 
@@ -12,7 +12,7 @@ You must perform three tasks to enable this feature\.
 
 1. [Activate X\-Ray in your application](#xray-sdk-java-aop-activate-xray)
 
-## Configuring spring<a name="xray-sdk-java-aop-spring-configuration"></a>
+## Configuring Spring<a name="xray-sdk-java-aop-spring-configuration"></a>
 
 You can use Maven or Gradle to configure Spring to use AOP to instrument your application\.
 
@@ -36,7 +36,7 @@ compile 'com.amazonaws:aws-xray-recorder-sdk-spring:2.4.0'
 
 Your classes must either be annotated with the `@XRayEnabled` annotation, or implement the `XRayTraced` interface\. This tells the AOP system to wrap the functions of the affected class for X\-Ray instrumentation\.
 
-## Activating x\-ray in your application<a name="xray-sdk-java-aop-activate-xray"></a>
+## Activating X\-Ray in your application<a name="xray-sdk-java-aop-activate-xray"></a>
 
 To activate X\-Ray tracing in your application, your code must extend the abstract class `AbstractXRayInterceptor` by overriding the following methods\.
 + `generateMetadata`—This function allows customization of the metadata attached to the current function’s trace\. By default, the class name of the executing function is recorded in the metadata\. You can add more data if you need additional insights\.


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
Based on all the other pages, "X-Ray" and "Spring" are the preferred names over "x-ray" and "spring".

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
