### PR TITLE
Updates incomplete Python Django onboarding steps

### DIFF
--- a/doc-source/xray-sdk-python-middleware.md
+++ b/doc-source/xray-sdk-python-middleware.md
@@ -55,6 +55,22 @@ MIDDLEWARE = [
 ]
 ```
 
+Add the X\-Ray SDK Django app to the `INSTALLED_APPS` list in your `settings.py` file\. This will allow the X\-Ray recorder to be configured during your app's startup.
+
+**Example settings\.py \- X\-Ray SDK Django App**  
+
+```
+INSTALLED_APPS = [
+    'aws_xray_sdk.ext.django',
+    'django.contrib.admin',
+    'django.contrib.auth',
+    'django.contrib.contenttypes',
+    'django.contrib.sessions',
+    'django.contrib.messages',
+    'django.contrib.staticfiles',
+]
+```
+
 Configure a segment name in your [`settings.py` file](xray-sdk-python-configuration.md#xray-sdk-python-middleware-configuration-django)\.
 
 **Example settings\.py – Segment name**  

--- a/doc-source/xray-sdk-python-middleware.md
+++ b/doc-source/xray-sdk-python-middleware.md
@@ -60,7 +60,7 @@ Configure a segment name in your [`settings.py` file](xray-sdk-python-configurat
 **Example settings\.py – Segment name**  
 
 ```
-XRAY_RECORDER = {,
+XRAY_RECORDER = {
     'AWS_XRAY_TRACING_NAME': 'My application',
     'PLUGINS': ('EC2Plugin'),
 }


### PR DESCRIPTION
*Description of changes:*
Include an extra required step to enable X-Ray on Django apps. If only the steps in the current docs are followed, an exception is raised upon a Django app's first request. This fixes that issue.

Also removes a comma that makes the JSON syntax invalid. This is important because many customers copy and paste sample code right from the docs so we should provide valid syntax.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
