### PR TITLE
Adding note about using a single plugin

### DIFF
--- a/doc-source/xray-sdk-python-configuration.md
+++ b/doc-source/xray-sdk-python-configuration.md
@@ -33,6 +33,8 @@ xray_recorder.configure(plugins=plugins)
 patch_all()
 ```
 
+**Note**: Since `plugins` are passed in as a tuple, be sure to include a trailing `,` when specifying a single plugin. For example, `plugins = ('EC2Plugin',)`
+
 You can also use [environment variables](#xray-sdk-python-configuration-envvars), which take precedence over values set in code, to configure the recorder\.
 
 Configure plugins before [patching libraries](#xray-sdk-python-configuration) to record downstream calls\.


### PR DESCRIPTION
*Description of changes:*
Adding a note about when using a single plugin, the trailing comma is necessary to avoid a `ModuleNotFoundError: No module named 'aws_xray_sdk.core.plugins.e'` error. It is by python's convention to have the trailing comma but may not be intuitive to new customers.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
