### PR TITLE
Updated docs to add full example of http client tracing

### DIFF
--- a/doc-source/xray-sdk-go-httpclients.md
+++ b/doc-source/xray-sdk-go-httpclients.md
@@ -9,3 +9,11 @@ Client creates a shallow copy of the provided http client, defaulting to `http.D
 ```
 myClient := xray.Client(http-client)
 ```
+
+**Example main\.go – Trace downstream HTTP call with ctxhttp library**
+
+Below example provides tracing outgoing http call with ctxhttp library using `xray.Client`. `ctx` can be passed from upstream call. 
+
+```
+resp, err := ctxhttp.Get(ctx, xray.Client(nil), url)
+```

--- a/doc-source/xray-sdk-go-httpclients.md
+++ b/doc-source/xray-sdk-go-httpclients.md
@@ -2,7 +2,7 @@
 
 When your application makes calls to microservices or public HTTP APIs, you can use the `xray.Client` to instrument those calls as subsegments of your Go application, as shown in the following example, where *http\-client* is an HTTP client\.
 
-Client creates a shallow copy of the provided http client, defaulting to `http.DefaultClient`, with roundtripper wrapped with `xray.RoundTripper`\.
+The client creates a shallow copy of the provided HTTP client, defaulting to `http.DefaultClient`, with roundtripper wrapped with `xray.RoundTripper`\.
 
 **Example main\.go – HTTP client**  
 
@@ -12,7 +12,7 @@ myClient := xray.Client(http-client)
 
 **Example main\.go – Trace downstream HTTP call with ctxhttp library**
 
-Below example provides tracing outgoing http call with ctxhttp library using `xray.Client`. `ctx` can be passed from upstream call. 
+The following example instruments the outgoing HTTP call with the ctxhttp library using `xray.Client`. `ctx` can be passed from the upstream call. This ensures that the existing segment context is used. For example, X-Ray does not allow a new segment to be created within a Lambda function, so the existing Lambda segment context should be used.
 
 ```
 resp, err := ctxhttp.Get(ctx, xray.Client(nil), url)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Added example of tracing downstream http call with `ctxhttp` library.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
