### PR TITLE
Update xray-daemon-configuration.md

### DIFF
--- a/doc-source/xray-daemon-configuration.md
+++ b/doc-source/xray-daemon-configuration.md
@@ -105,7 +105,7 @@ You can also use a YAML format file to configure the daemon\. Pass the configura
   + `TCPAddress` – Listen for [calls to the X\-Ray service](xray-api-sampling.md) on a different TCP port\.
 + `Logging` – Configure logging behavior\.
   + `LogRotation` – Set to `false` to disable log rotation\.
-  + `LogLevel` – Change the log level, from most verbose to least: `dev`, `debug`, `info`, `warn`, `error`, `prod` \(default\)\.
+  + `LogLevel` – Change the log level, from most verbose to least: `dev`, `debug`, `info`, `warn`, `error`\. The default is `prod`, which is equivalent to `info`\.
   + `LogPath` – Output logs to the specified file path\.
 + `LocalMode` – Set to `true` to skip checking for EC2 instance metadata\.
 + `ResourceARN` – Amazon Resource Name \(ARN\) of the AWS resource running the daemon\.


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-xray-daemon/issues/95

*Description of changes:*
Corrects the documentation for log level to indicate that `prod` is `info`-level. Currently the docs imply `prod` is the least verbose level, which it is not.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
