### PR TITLE
Update xray-sdk-dotnet-configuration.md to add warning when using console as logging option

### DIFF
--- a/doc-source/xray-sdk-dotnet-configuration.md
+++ b/doc-source/xray-sdk-dotnet-configuration.md
@@ -159,7 +159,7 @@ AWSXRayRecorder.InitializeInstance(configuration,recorder);
 
 ## Logging \(\.NET\)<a name="xray-sdk-dotnet-configuration-logging"></a>
 
-The X\-Ray SDK for \.NET uses the same logging mechanism as the AWS SDK for \.NET\. If you already configured your application to log AWS SDK for \.NET output, the same configuration applies to output from the X\-Ray SDK for \.NET\.
+The X\-Ray SDK for \.NET uses the same logging mechanism as the [AWS SDK for .NET](https://docs.aws.amazon.com/sdk-for-net/v3/developer-guide/net-dg-config-other.html#config-setting-awslogging). If you already configured your application to log AWS SDK for \.NET output, the same configuration applies to output from the X\-Ray SDK for \.NET\.
 
 To configure logging, add a configuration section named `aws` to your `App.config` file or `Web.config` file\.
 
@@ -181,9 +181,7 @@ For more information, see [Configuring Your AWS SDK for \.NET Application](https
 
 ## Logging \(\.NET Core\)<a name="xray-sdk-dotnet-configuration-corelogging"></a>
 
-For \.NET Core applications, the X\-Ray SDK supports the logging options in the AWS SDK for \.NET [LoggingOptions enum](https://docs.aws.amazon.com/sdkfornet/v3/apidocs/items/Amazon/TLoggingOptions.html)\.
-
-*Note*: `LoggingOptions.Console` will emit all detailed logs regardless of the logging level, which may result in excessive charges in some use case (e.g., export logs to AWS CloudWatch)\.
+The X\-Ray SDK for \.NET uses the same logging mechanism as the [AWS SDK for .NET](https://docs.aws.amazon.com/sdk-for-net/v3/developer-guide/net-dg-config-other.html#config-setting-awslogging). To configure logging for .NET Core application, pass the logging option to the `AWSXRayRecorder.RegisterLogger` method.
 
 For example, to use log4net, create a configuration file that defines the logger, the output format, and the file location\.
 
@@ -205,7 +203,7 @@ For example, to use log4net, create a configuration file that defines the logger
 </log4net>
 ```
 
-Then, create the logger and apply the configuration by passing the logging option to the `AWSXRayRecorder.RegisterLogger` method in your program code\.
+Then, create the logger and apply the configuration in your program code\.
 
 **Example \.NET Core Program\.cs – Logging**  
 

--- a/doc-source/xray-sdk-dotnet-configuration.md
+++ b/doc-source/xray-sdk-dotnet-configuration.md
@@ -181,11 +181,9 @@ For more information, see [Configuring Your AWS SDK for \.NET Application](https
 
 ## Logging \(\.NET Core\)<a name="xray-sdk-dotnet-configuration-corelogging"></a>
 
-For \.NET Core applications, the X\-Ray SDK supports the logging options in the AWS SDK for \.NET [LoggingOptions enum](https://docs.aws.amazon.com/sdkfornet/v3/apidocs/items/Amazon/TLoggingOptions.html)\. To configure logging, pass one of these options to the `RegisterLogger` method\.
+For \.NET Core applications, the X\-Ray SDK supports the logging options in the AWS SDK for \.NET [LoggingOptions enum](https://docs.aws.amazon.com/sdkfornet/v3/apidocs/items/Amazon/TLoggingOptions.html)\.
 
-```
-AWSXRayRecorder.RegisterLogger(LoggingOptions.Console);
-```
+*Note*: `LoggingOptions.Console` will emit all detailed logs regardless of the logging level, which may result in excessive charges in some use case (e.g., export logs to AWS CloudWatch)\.
 
 For example, to use log4net, create a configuration file that defines the logger, the output format, and the file location\.
 
@@ -207,7 +205,7 @@ For example, to use log4net, create a configuration file that defines the logger
 </log4net>
 ```
 
-Then, create the logger and apply the configuration in your program code\.
+Then, create the logger and apply the configuration by passing the logging option to the `AWSXRayRecorder.RegisterLogger` method in your program code\.
 
 **Example \.NET Core Program\.cs – Logging**  
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Update `xray-sdk-dotnet-configuration.md` to add warning when using console as logging option for .NET Core.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
