### PR TITLE
Fix Python code generating trace ids

### DIFF
--- a/doc-source/xray-api-sendingdata.md
+++ b/doc-source/xray-api-sendingdata.md
@@ -82,7 +82,7 @@ import binascii
 
 START_TIME = time.time()
 HEX=hex(int(START_TIME))[2:]
-TRACE_ID="1-{}-{}".format(HEX, binascii.hexlify(os.urandom(12)))
+TRACE_ID="1-{}-{}".format(HEX, binascii.hexlify(os.urandom(12)).decode('utf-8'))
 ```
 
 **Bash**


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This pull request fixes the Python sample that generates random trace ids.  `hexlify` returns `bytes` so without a `decode`, the resulting trace id looks like `1-62019ad2-b'58642b5ec9f4cf96da868a7b'` which is not valid.  This commit converts the byte array to a string.

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
