### PR TITLE
Fix typo in require sampling rules

### DIFF
--- a/doc-source/xray-sdk-ruby-configuration.md
+++ b/doc-source/xray-sdk-ruby-configuration.md
@@ -115,7 +115,7 @@ my_sampling_rules =  {
 
 ```
 require 'aws-xray-sdk'
-require config/sampling-rules.rb
+require 'config/sampling-rules.rb'
 
 config = {
   sampling_rules: my_sampling_rules,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Fix missing single quotes around `require` statement in sampling rules example.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
